### PR TITLE
Use global hope

### DIFF
--- a/CardsForClimateUnityProj/Assets/Scripts/ActionCardDisplay.cs
+++ b/CardsForClimateUnityProj/Assets/Scripts/ActionCardDisplay.cs
@@ -211,7 +211,7 @@ public class ActionCardDisplay : MonoBehaviour, IBeginDragHandler, IDragHandler,
             if (raycastResults[i].gameObject.CompareTag("Card Play Square"))
             {
                 // First, we make sure that this card is valid to be played
-                if (GameManager.Instance.PlayerCardsHope() && GameManager.Instance.ValidCard(MyCard))
+                if (GameManager.Instance.ValidCard(MyCard))
                 {
                     // If valid, we add the card to the card catcher square's collection
                     // and tell the GameManager to play this card.

--- a/CardsForClimateUnityProj/Assets/Scripts/GameManager.cs
+++ b/CardsForClimateUnityProj/Assets/Scripts/GameManager.cs
@@ -50,7 +50,7 @@ public class GameManager : MonoBehaviour
 
     /// <summary>
     /// Capital-H Hope is a property that controls access to and updating of
-    /// lowercase-m hope, the backing value. It also ensures that the Hope UI
+    /// lowercase-h hope, the backing value. It also ensures that the Hope UI
     /// stays in sync with the hope value.
     /// Starts at Full and can be decremented until it is Empty.
     /// </summary>
@@ -536,10 +536,10 @@ public class GameManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Checks if any the player must play a hope card in their next play.
+    /// Checks if the player must play a hope card in their next play.
     /// </summary>
     public bool PlayerMustPlayHope() {
-        return Hope == MIN_HOPE + 1;
+        return (Hope == MIN_HOPE + 1 && activePlayerCardCount == 0);
     }
 
 


### PR DESCRIPTION
Closes #29 

Switch to a true global hope counter, not per-hand. Allows players to _not_ have to play a hope card unless they are at risk of running out of hope (i.e. hope is at 1).

Other code-only changes:

- Switches hope to use positive ints instead of negatives (starts at 3, game over at 0)
- Consolidates hope UI updates into the `set` part of `Hope` value